### PR TITLE
change event to layout_load_before

### DIFF
--- a/etc/events.xml
+++ b/etc/events.xml
@@ -8,7 +8,7 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
-    <event name="controller_action_predispatch">
+    <event name="layout_load_before">
         <observer name="samgranger_storecodebodyclass" instance="SamGranger\StoreCodeBodyClass\Plugin\StoreCodeBodyClassPlugin" shared="false" />
     </event>
 </config>


### PR DESCRIPTION
Event controller_action_predispatch will only work on CMS and product page. On category page
you will get the exception: Catalog Layer has been already created, throwed on [Magento\Catalog\Model\Layer\Resolver (54)](https://github.com/magento/magento2/blob/develop/app/code/Magento/Catalog/Model/Layer/Resolver.php#L54), because the
layer has been already created.

Using event layout_load_before will make it works on every page. Such even is triggered [here](https://github.com/magento/magento2/blob/develop/lib/internal/Magento/Framework/View/Layout/Builder.php#L80), it will allow you to modify every page layout before it gets rendered.